### PR TITLE
Add a default role to be given to every user

### DIFF
--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -30,5 +30,8 @@ func newFlagSet() *flag.FlagSet {
 	flagSet.Var(&util.StringArray{}, "auth-backend-role", "A SAR to check to allow the given backend role(i.e. admin={'namespace':'default','verb':'get','resource':'pods/logs'}")
 	flagSet.Var(&util.StringArray{}, "auth-whitelisted-name", "A name compared against cert CN for which a request will be passed through")
 
+	//auth-default-role-name is the role given to any user request
+	flagSet.String("auth-default-role-name", "", "The backend role that is associated with any user")
+
 	return flagSet
 }

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -43,6 +43,9 @@ type Options struct {
 	//with no additional processing
 	AuthWhiteListedNames []string `flag:"auth-whitelisted-name"`
 
+	//AuthDefaultRoleName is the role associated to every request
+	AuthDefaultRoleName string `flag:"auth-default-role-name"`
+
 	//OCP Cluster Logging configs
 	cltypes.ExtConfig
 }

--- a/pkg/config/options_test.go
+++ b/pkg/config/options_test.go
@@ -61,6 +61,24 @@ var _ = Describe("Initializing Config options", func() {
 		})
 
 	})
+
+	Describe("when defining the default role name", func() {
+		It("should succeed with an empty value", func() {
+			args := []string{"--auth-default-role-name="}
+			options, err := config.Init(args)
+			Expect(err).Should(BeNil())
+			Expect(options).Should(Not(BeNil()))
+			Expect(options.AuthDefaultRoleName).Should(BeEmpty())
+		})
+		It("should succeed with any value", func() {
+			args := []string{"--auth-default-role-name=foo"}
+			options, err := config.Init(args)
+			Expect(err).Should(BeNil())
+			Expect(options).Should(Not(BeNil()))
+			Expect(options.AuthDefaultRoleName).Should(Equal("foo"))
+		})
+	})
+
 	Describe("when defining auth backend role", func() {
 		Describe("without a valid backendname", func() {
 

--- a/pkg/handlers/authorization/handler.go
+++ b/pkg/handlers/authorization/handler.go
@@ -82,7 +82,11 @@ func (auth *authorizationHandler) Process(req *http.Request, context *handlers.R
 			context.Roles = append(context.Roles, name)
 		}
 	}
-	req.Header.Add(headerForwardedRoles, strings.Join(context.RoleSet().List(), ","))
+	roleSet := context.RoleSet().List()
+	if auth.config.AuthDefaultRoleName != "" {
+		roleSet = append(roleSet, auth.config.AuthDefaultRoleName)
+	}
+	req.Header.Add(headerForwardedRoles, strings.Join(roleSet, ","))
 	return req, nil
 }
 

--- a/pkg/handlers/authorization/handler_test.go
+++ b/pkg/handlers/authorization/handler_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Process", func() {
 					"roleA": config.BackendRoleConfig{},
 					"roleB": config.BackendRoleConfig{},
 				},
+				AuthDefaultRoleName: "defaultRole",
 			},
 		}
 	})
@@ -99,7 +100,7 @@ var _ = Describe("Process", func() {
 		It("should add role headers to the request", func() {
 			entries, ok := req.Header["X-Forwarded-Roles"]
 			Expect(ok).To(BeTrue(), fmt.Sprintf("Expected a user's roles to be added to be proxy headers: %v", req.Header))
-			Expect(entries).To(Equal([]string{"roleA,roleB"}))
+			Expect(entries).To(Equal([]string{"roleA,roleB,defaultRole"}))
 		})
 		It("should add a user's projects to the request", func() {
 			entries, ok := req.Header["X-Ocp-Ns"]


### PR DESCRIPTION
This PR:
* add configuration to allow supplying a default role to every user

This is useful if we are able to define a static role that applies to every user.  In cluster logging's case we define a role that controls access based on DLS

cc @openshift/openshift-team-logging @pavolloffay 