### PR TITLE
update default elasticsearch to use localhost in lieu of 127.0.0.1

### DIFF
--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -15,7 +15,7 @@ func newFlagSet() *flag.FlagSet {
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
 	flagSet.String("tls-client-ca", "", "path to a CA file for admitting client certificates.")
-	flagSet.String("elasticsearch-url", "https://127.0.0.1:9200", "The default URL to Elasticsearch")
+	flagSet.String("elasticsearch-url", "https://localhost:9200", "The default URL to Elasticsearch")
 
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 	flagSet.Bool("proxy-websockets", true, "enables WebSocket proxying")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -71,7 +71,7 @@ func newOptions() *Options {
 	return &Options{
 		ProxyWebSockets:  true,
 		ListeningAddress: ":443",
-		Elasticsearch:    "https://127.0.0.1:9200",
+		Elasticsearch:    "https://localhost:9200",
 		UpstreamFlush:    time.Duration(5) * time.Millisecond,
 		RequestLogging:   false,
 		AuthBackEndRoles: map[string]BackendRoleConfig{},

--- a/pkg/config/options_test.go
+++ b/pkg/config/options_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Initializing Config options", func() {
 			options, err := config.Init(args)
 			Expect(err).Should(BeNil())
 			Expect(options).Should(Not(BeNil()))
-			Expect(&url.URL{Scheme: "https", Host: "127.0.0.1:9200", Path: "/"}).Should(Equal(options.ElasticsearchURL))
+			Expect(&url.URL{Scheme: "https", Host: "localhost:9200", Path: "/"}).Should(Equal(options.ElasticsearchURL))
 		})
 	})
 


### PR DESCRIPTION
Remove 127.0.0.1 for ipv6 support