### PR TITLE
disable cluster logging handler

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/openshift/elasticsearch-proxy/pkg/config"
 	auth "github.com/openshift/elasticsearch-proxy/pkg/handlers/authorization"
-	cl "github.com/openshift/elasticsearch-proxy/pkg/handlers/clusterlogging"
+
 	"github.com/openshift/elasticsearch-proxy/pkg/proxy"
 	log "github.com/sirupsen/logrus"
 )
@@ -29,7 +29,6 @@ func main() {
 
 	log.Printf("Registering Handlers....")
 	proxyServer.RegisterRequestHandlers(auth.NewHandlers(opts))
-	proxyServer.RegisterRequestHandlers(cl.NewHandlers(opts))
 
 	var h http.Handler = proxyServer
 	if opts.RequestLogging {

--- a/pkg/handlers/authorization/handler.go
+++ b/pkg/handlers/authorization/handler.go
@@ -28,7 +28,7 @@ type authorizationHandler struct {
 }
 
 //NewHandlers is the initializer for this handler
-func NewHandlers(opts *config.Options) (_ []handlers.RequestHandler) {
+func NewHandlers(opts *config.Options) []handlers.RequestHandler {
 	osClient, err := clients.NewOpenShiftClient()
 	if err != nil {
 		log.Fatalf("Error constructing OpenShiftClient %v", err)


### PR DESCRIPTION
This PR:
* disables the cluser logging handler as I believe its not required given we have static roles.