### PR TITLE
Forward the cert subject to upstream on successful mTLS

### DIFF
--- a/pkg/handlers/authorization/certificates.go
+++ b/pkg/handlers/authorization/certificates.go
@@ -4,12 +4,13 @@ import (
 	"net/http"
 )
 
-//certCNExtractor takes a request and extracts the CN from the certificates
-type certCNExtractor func(req *http.Request) string
+//certSubjectExtractor takes a request and extracts the subject from the certificates
+//in RFC 2253 Distinguished Names syntax.
+type certSubjectExtractor func(req *http.Request) string
 
-func defaultCertCNExtractor(req *http.Request) string {
+func defaultCertSubjectExtractor(req *http.Request) string {
 	if req.TLS != nil && len(req.TLS.VerifiedChains) > 0 && len(req.TLS.VerifiedChains[0]) > 0 {
-		return req.TLS.VerifiedChains[0][0].Subject.CommonName
+		return req.TLS.VerifiedChains[0][0].Subject.String()
 	}
 	return ""
 }

--- a/pkg/handlers/authorization/handler_test.go
+++ b/pkg/handlers/authorization/handler_test.go
@@ -38,15 +38,15 @@ var _ = Describe("Process", func() {
 		}
 	})
 
-	Context("when certs with whitelisted CN is provided", func() {
+	Context("when certs with whitelisted Subject is provided", func() {
 		It("should pass the request with no changes", func() {
-			handler.config.AuthWhiteListedNames = []string{"foo"}
-			handler.fnCNExtractor = func(req *http.Request) string {
-				return "foo"
+			handler.config.AuthWhiteListedNames = []string{"CN=foo,OU=org-unit,O=org"}
+			handler.fnSubjectExtractor = func(req *http.Request) string {
+				return "CN=foo,OU=org-unit,O=org"
 			}
 			req, err = handler.Process(req, context)
 			Expect(err).To(BeNil())
-			Expect(req.Header).To(BeEmpty())
+			Expect(req.Header.Get("X-Forwarded-User")).To(Equal("CN=foo,OU=org-unit,O=org"))
 
 			Expect(context.WhiteListedNames).To(Equal(handler.config.AuthWhiteListedNames))
 		})

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -17,6 +16,7 @@ import (
 	configOptions "github.com/openshift/elasticsearch-proxy/pkg/config"
 	handlers "github.com/openshift/elasticsearch-proxy/pkg/handlers"
 	"github.com/openshift/elasticsearch-proxy/pkg/util"
+	log "github.com/sirupsen/logrus"
 	"github.com/yhat/wsutil"
 )
 
@@ -151,7 +151,6 @@ func (p *ProxyServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 	log.Printf("Request: %v", alteredReq)
 	p.serveMux.ServeHTTP(rw, alteredReq)
-	// }
 }
 
 func (p *ProxyServer) StructuredError(rw http.ResponseWriter, err error) {


### PR DESCRIPTION
Based on the fact that we have a successful mTLS connection established this PR simplifies the whitelisting of the whole subject by passing it in RFC 2253 format to the upstream elasticsearch instance. Latter builds upon the trust that the proxy verified the request originator and uses the subject to map the roles.