### PR TITLE
Retrieve user info from: bearertoken, certificate subject

### DIFF
--- a/pkg/proxy/http.go
+++ b/pkg/proxy/http.go
@@ -43,7 +43,7 @@ func (s *Server) ServeHTTPS() {
 	}
 
 	if len(s.Opts.TLSClientCAFile) > 0 {
-		config.ClientAuth = tls.RequireAndVerifyClientCert
+		config.ClientAuth = tls.VerifyClientCertIfGiven
 		config.ClientCAs, err = util.GetCertPool([]string{s.Opts.TLSClientCAFile}, false)
 		if err != nil {
 			log.Fatalf("FATAL: %s", err)


### PR DESCRIPTION
This PR modifies:
* Modifies Retrieval of user info from: bearertoken, certificate subject
* Sanitize headers to remove those we are passing to elasticsearch

@periklis we additionally have a problem that sg_admin_role is defined incorrectly in the EO. it should be "view pods/logs" not metrics.. but this only affects admin