### PR TITLE
Serve metrics on separate listener with injected PKI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/keegancsmith/rpc v1.1.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mreiferson/go-options v0.0.0-20190302064952-20ba7d382d05
+	github.com/newhook/go-symbols v0.0.0-20151212134530-b75dfefa0d23 // indirect
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
 	github.com/openshift/api v0.0.0-20180830153656-5ad8479f64f1

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mreiferson/go-options v0.0.0-20190302064952-20ba7d382d05 h1:9cELXrXqZu2sczHBZHRpZ+84SR27+yXSKb1MBiUaPhA=
 github.com/mreiferson/go-options v0.0.0-20190302064952-20ba7d382d05/go.mod h1:zHtCks/HQvOt8ATyfwVe3JJq2PPuImzXINPRTC03+9w=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/newhook/go-symbols v0.0.0-20151212134530-b75dfefa0d23 h1:bXKgb2O/gIrZd/smUeP3OJcAt1ey3UV+cPYT+mRUNzs=
+github.com/newhook/go-symbols v0.0.0-20151212134530-b75dfefa0d23/go.mod h1:9RIESfVnNNAkdTKNuEYS0rEkXXM2HYfchPD4xXNx1CU=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -15,6 +15,11 @@ func newFlagSet() *flag.FlagSet {
 	flagSet.String("tls-cert", "", "path to certificate file")
 	flagSet.String("tls-key", "", "path to private key file")
 	flagSet.String("tls-client-ca", "", "path to a CA file for admitting client certificates.")
+
+	flagSet.String("metrics-listening-address", "", "<addr>:<port> to listen on for HTTPS metrics clients")
+	flagSet.String("metrics-tls-cert", "", "path to certificate file from the metrics service")
+	flagSet.String("metrics-tls-key", "", "path to private key file from the metrics service")
+
 	flagSet.String("elasticsearch-url", "https://localhost:9200", "The default URL to Elasticsearch")
 
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -22,6 +22,10 @@ type Options struct {
 	TLSClientCAFile  string   `flag:"tls-client-ca"`
 	OpenShiftCAs     []string `flag:"openshift-ca"`
 
+	MetricsListeningAddress string `flag:"metrics-listening-address"`
+	MetricsTLSCertFile      string `flag:"metrics-tls-cert"`
+	MetricsTLSKeyFile       string `flag:"metrics-tls-key"`
+
 	Elasticsearch    string `flag:"elasticsearch-url"`
 	ElasticsearchURL *url.URL
 	UpstreamFlush    time.Duration `flag:"upstream-flush"`
@@ -105,6 +109,10 @@ func (o *Options) Validate() error {
 
 	if len(o.TLSClientCAFile) > 0 && (len(o.TLSKeyFile) == 0 || len(o.TLSCertFile) == 0) {
 		msgs = append(msgs, "tls-client-ca requires tls-key-file or tls-cert-file to be set to listen on tls")
+	}
+
+	if o.MetricsListeningAddress != "" && (o.MetricsTLSCertFile == "" || o.MetricsTLSKeyFile == "") {
+		msgs = append(msgs, "metrics-listening-address requires metrics-tls-cert and metrics-tls-key to be set")
 	}
 
 	//Auth Handler validations

--- a/pkg/config/options_test.go
+++ b/pkg/config/options_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Initializing Config options", func() {
 
 	Describe("when defining tls-client-ca without key or certs", func() {
 		It("should fail", func() {
-			args := []string{"--tls-client-ca=/foo/bar"}
+			args := []string{"--tls-client-ca=/foo/bar", "--metrics-tls-cert=/foo/bar", "--metrics-tls-key=/foo/bar"}
 			options, err := config.Init(args)
 			Expect(options).Should(BeNil())
 
@@ -33,11 +33,29 @@ var _ = Describe("Initializing Config options", func() {
 
 	Describe("when defining tls-client-ca and key without certs", func() {
 		It("should fail", func() {
-			args := []string{"--tls-client-ca=/foo/bar", "--tls-key=/foo/bar"}
+			args := []string{"--tls-client-ca=/foo/bar", "--tls-key=/foo/bar", "--metrics-tls-cert=/foo/bar", "--metrics-tls-key=/foo/bar"}
 			options, err := config.Init(args)
 			Expect(options).Should(BeNil())
 			Expect(err.Error()).Should(
 				Equal(errorMessage("tls-client-ca requires tls-key-file or tls-cert-file to be set to listen on tls")))
+		})
+	})
+
+	Describe("when defining metrics-listening-address", func() {
+		It("should fail without metrics-tls-cert", func() {
+			args := []string{"--metrics-listening-address=:60001", "--metrics-tls-key=/foo/bar"}
+			options, err := config.Init(args)
+			Expect(options).Should(BeNil())
+			Expect(err.Error()).Should(
+				Equal(errorMessage("metrics-listening-address requires metrics-tls-cert and metrics-tls-key to be set")))
+		})
+
+		It("should fail without metrics-tls-key", func() {
+			args := []string{"--metrics-listening-address=:60001", "--metrics-tls-cert=/foo/bar"}
+			options, err := config.Init(args)
+			Expect(options).Should(BeNil())
+			Expect(err.Error()).Should(
+				Equal(errorMessage("metrics-listening-address requires metrics-tls-cert and metrics-tls-key to be set")))
 		})
 	})
 

--- a/pkg/handlers/logging/handler.go
+++ b/pkg/handlers/logging/handler.go
@@ -1,7 +1,7 @@
 // largely adapted from https://github.com/gorilla/handlers/blob/master/handlers.go
 // to add logging of request duration as last value (and drop referrer)
 
-package proxy
+package logging
 
 import (
 	"fmt"
@@ -71,7 +71,7 @@ type loggingHandler struct {
 	enabled bool
 }
 
-func LoggingHandler(out io.Writer, h http.Handler, v bool) http.Handler {
+func NewHandler(out io.Writer, h http.Handler, v bool) http.Handler {
 	return loggingHandler{out, h, v}
 }
 

--- a/pkg/proxy/http.go
+++ b/pkg/proxy/http.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/openshift/elasticsearch-proxy/pkg/config"
 	"github.com/openshift/elasticsearch-proxy/pkg/util"
@@ -21,8 +20,7 @@ func (s *Server) ListenAndServe() {
 	if s.Opts.ListeningAddress == "" {
 		log.Fatalf("FATAL: must specify https-addres")
 	}
-	go s.ServeHTTPS()
-	select {}
+	s.ServeHTTPS()
 }
 
 func (s *Server) ServeHTTPS() {
@@ -65,22 +63,4 @@ func (s *Server) ServeHTTPS() {
 	}
 
 	log.Printf("HTTPS: closing %s", tlsListener.Addr())
-}
-
-// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
-// connections. It's used by ListenAndServe and ListenAndServeTLS so
-// dead TCP connections (e.g. closing laptop mid-download) eventually
-// go away.
-type tcpKeepAliveListener struct {
-	*net.TCPListener
-}
-
-func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
-	tc, err := ln.AcceptTCP()
-	if err != nil {
-		return
-	}
-	tc.SetKeepAlive(true)
-	tc.SetKeepAlivePeriod(3 * time.Minute)
-	return tc, nil
 }

--- a/pkg/proxy/keep_alive.go
+++ b/pkg/proxy/keep_alive.go
@@ -1,0 +1,24 @@
+package proxy
+
+import (
+    "net"
+    "time"
+)
+
+// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type tcpKeepAliveListener struct {
+    *net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+    tc, err := ln.AcceptTCP()
+    if err != nil {
+        return
+    }
+    tc.SetKeepAlive(true)
+    tc.SetKeepAlivePeriod(3 * time.Minute)
+    return tc, nil
+}

--- a/pkg/proxy/metrics.go
+++ b/pkg/proxy/metrics.go
@@ -1,0 +1,54 @@
+package proxy
+
+import (
+    "crypto/tls"
+    "log"
+    "net"
+    "net/http"
+    "strings"
+
+    "github.com/openshift/elasticsearch-proxy/pkg/config"
+)
+
+type MetricsServer struct {
+    Handler http.Handler
+    Opts    *config.Options
+}
+
+func (s *MetricsServer) ListenAndServe() {
+    s.ServeHTTPS()
+}
+
+func (s *MetricsServer) ServeHTTPS() {
+    addr := s.Opts.MetricsListeningAddress
+    config := &tls.Config{
+        MinVersion: tls.VersionTLS12,
+        MaxVersion: tls.VersionTLS12,
+    }
+    if config.NextProtos == nil {
+        config.NextProtos = []string{"http/1.1"}
+    }
+
+    var err error
+    config.Certificates = make([]tls.Certificate, 1)
+    config.Certificates[0], err = tls.LoadX509KeyPair(s.Opts.MetricsTLSCertFile, s.Opts.MetricsTLSKeyFile)
+    if err != nil {
+        log.Fatalf("FATAL: loading metrics tls config (%s, %s) failed - %s", s.Opts.MetricsTLSCertFile, s.Opts.MetricsTLSKeyFile, err)
+    }
+
+    ln, err := net.Listen("tcp", addr)
+    if err != nil {
+        log.Fatalf("FATAL: listen (%s) failed - %s", addr, err)
+    }
+    log.Printf("HTTPS: listening on %s", ln.Addr())
+
+    tlsListener := tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, config)
+    srv := &http.Server{Handler: s.Handler}
+    err = srv.Serve(tlsListener)
+
+    if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+        log.Printf("ERROR: https.Serve() - %s", err)
+    }
+
+    log.Printf("HTTPS: closing %s", tlsListener.Addr())
+}


### PR DESCRIPTION
This PR adds a separate listener to serve metrics through the proxy using the injected PKI as annotated in the metrics service.