### PR TITLE
Bug 1879748: return 401 from api server

### DIFF
--- a/pkg/handlers/authorization/handler.go
+++ b/pkg/handlers/authorization/handler.go
@@ -2,7 +2,6 @@ package authorization
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -61,7 +60,7 @@ func (auth *authorizationHandler) Process(req *http.Request, context *handlers.R
 		log.Trace("Handling a request with token...")
 		rolesProjects, err := auth.cache.getRolesAndProjects(context.Token)
 		if err != nil {
-			return req, fmt.Errorf("Could not determine the user or their roles: %v", err)
+			return req, err
 		}
 		context.UserName = rolesProjects.review.UserName()
 		if context.UserName == "" {

--- a/pkg/handlers/authorization/roles_projects_service.go
+++ b/pkg/handlers/authorization/roles_projects_service.go
@@ -49,9 +49,13 @@ func loadFromOpenshift(roleConfig map[string]config.BackendRoleConfig, client cl
 	return func(key interface{}) (interface{}, error) {
 		token := key.(string)
 		tokenReview, err := client.TokenReview(token)
+		log.Debugf("TokenReview: %v", tokenReview)
 		if err != nil {
 			log.Errorf("Error fetching user info %v", err)
 			return nil, err
+		}
+		if !tokenReview.Status.Authenticated {
+			return nil, handlers.NewError("401", tokenReview.Status.Error)
 		}
 		ctx := &handlers.RequestContext{}
 		ctx.UserName = tokenReview.UserName()

--- a/pkg/handlers/types.go
+++ b/pkg/handlers/types.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -44,6 +45,12 @@ type StructuredError struct {
 	Code    int    `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
 	Error   error  `json:"error,omitempty"`
+}
+
+//NewError returns an error with a code and message that can be returned
+//as a structured error understandable by Kibana
+func NewError(code, message string) error {
+	return fmt.Errorf("got %s %s", code, message)
 }
 
 func NewStructuredError(err error) StructuredError {


### PR DESCRIPTION
This PR:
* returns a proper 401 when auth fails trying to retrieve a user's info and evaluate SAR

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1879748

This PR is a necessary change to resolve kibana 501 errors when a user's token expires