### PR TITLE
Bug 1880960: Enable pprof endpoints on non-default serveMux

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"strings"
 

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httputil"
+	"net/http/pprof"
 	"net/url"
 	"strings"
 	"time"
@@ -118,6 +119,13 @@ func NewWebSocketOrRestReverseProxy(u *url.URL, opts *configOptions.Options) (re
 
 func NewProxyServer(opts *configOptions.Options) *ProxyServer {
 	serveMux := http.NewServeMux()
+
+	serveMux.HandleFunc("/debug/pprof/", pprof.Index)
+	serveMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	serveMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	serveMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	serveMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
 	u := opts.ElasticsearchURL
 	path := u.Path
 	switch u.Scheme {


### PR DESCRIPTION
### Description
This PR re-enables the pprof endpoints for the elasticsearch-proxy. The present state was broken because we use a non-default `serveMux` and in turn auto-registration is skipped. The fix registers each endpoint separately for the custom `serveMux`. The endpoints are only available through the main proxy endpoints and not via the metrics endpoint. This approach requires mTLS based authentication to access the endpoints, e.g. via port-forward:
```
curl -sk -v --cacert ./admin-ca.crt --cert ./logging-es.crt --key ./logging-es.key https://localhost:60000/debug/pprof/heap > heap.pprof
```

/cc @blockloop  
/assign @ewolinetz 
 
### Links
- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1880960
