### PR TITLE
Bug 1880960: Add limit for max idle conns per http transport config

### DIFF
--- a/pkg/clients/elasticsearch.go
+++ b/pkg/clients/elasticsearch.go
@@ -82,7 +82,10 @@ func NewElasticsearchClient(skipVerify bool, serverURL, adminCert, adminKey stri
 			serverURL,
 		},
 		Transport: &http.Transport{
+			MaxIdleConns:          100,
 			MaxIdleConnsPerHost:   10,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
 			ResponseHeaderTimeout: time.Second,
 			DialContext:           (&net.Dialer{Timeout: time.Second}).DialContext,
 			TLSClientConfig: &tls.Config{

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -53,8 +53,11 @@ func NewReverseProxy(target *url.URL, upstreamFlush time.Duration, rootCAs []str
 	proxy.FlushInterval = upstreamFlush
 
 	transport := &http.Transport{
-		MaxIdleConnsPerHost: 500,
-		IdleConnTimeout:     1 * time.Minute,
+		MaxIdleConns:          1000,
+		MaxIdleConnsPerHost:   500,
+		IdleConnTimeout:       1 * time.Minute,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 	}
 	if len(rootCAs) > 0 {
 		pool, err := util.GetCertPool(rootCAs, false)


### PR DESCRIPTION
### Description
This PR addresses an unbound memory usage scenario by limiting the max amount of idle connections in `http.Transport`.

/cc @blockloop 
/assign @ewolinetz 
 
### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1880960
