### PR TITLE
Bug 1886856: Enable responseLogger on debug LOG_LEVEL to reduce string copies

### DIFF
--- a/pkg/handlers/types.go
+++ b/pkg/handlers/types.go
@@ -63,7 +63,7 @@ func NewStructuredError(err error) StructuredError {
 			if parsedCode, parseError := strconv.Atoi(parts[1]); parseError == nil {
 				code = parsedCode
 			} else {
-				log.Printf("Unable to parse response code from response %v", err.Error())
+				log.Errorf("Unable to parse response code from response %v", err.Error())
 			}
 		}
 		if len(parts) >= 3 {

--- a/pkg/proxy/response_handler.go
+++ b/pkg/proxy/response_handler.go
@@ -26,3 +26,12 @@ func (rl *responseLogger) WriteHeader(statusCode int) {
 	log.Debugf("Response statusCode %d", statusCode)
 	rl.rw.WriteHeader(statusCode)
 }
+
+func NewResponseWriter(rw http.ResponseWriter) http.ResponseWriter {
+	if log.GetLevel() >= log.DebugLevel {
+		return &responseLogger{
+			rw,
+		}
+	}
+	return rw
+}

--- a/pkg/proxy/response_handler_test.go
+++ b/pkg/proxy/response_handler_test.go
@@ -1,0 +1,30 @@
+package proxy
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewResponseWriter", func() {
+
+	var (
+		rw = &responseLogger{}
+	)
+
+	Context("when LOG_LEVEL >= debug", func() {
+		It("should return a responseLogger", func() {
+			log.SetLevel(log.TraceLevel)
+			act := NewResponseWriter(rw)
+			Expect(act).To(Not(BeIdenticalTo(rw)))
+		})
+	})
+	Context("when LOG_LEVEL < debug", func() {
+		It("should return the http.ResponseWriter it was given", func() {
+			log.SetLevel(log.InfoLevel)
+			Expect(NewResponseWriter(rw)).To(BeIdenticalTo(rw))
+		})
+	})
+
+})

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -152,19 +152,19 @@ func (p *ProxyServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	log.Tracef("Headers: %v", req.Header)
 	var err error
 	alteredReq := req
-	responseLogger := &responseLogger{rw}
+	responseWriter := NewResponseWriter(rw)
 	context := handlers.RequestContext{}
 	for _, reqhandler := range p.requestHandlers {
 		alteredReq, err = reqhandler.Process(alteredReq, &context)
 		log.Debugf("Handling request %q", reqhandler.Name())
 		if err != nil {
-			log.Printf("Error processing request in handler %s: %v", reqhandler.Name(), err)
-			p.StructuredError(responseLogger, err)
+			log.Errorf("Error processing request in handler %s: %v", reqhandler.Name(), err)
+			p.StructuredError(responseWriter, err)
 			return
 		}
 	}
 	log.Debugf("Request: %v", alteredReq)
-	p.serveMux.ServeHTTP(responseLogger, alteredReq)
+	p.serveMux.ServeHTTP(responseWriter, alteredReq)
 }
 
 func (p *ProxyServer) StructuredError(rw http.ResponseWriter, err error) {

--- a/pkg/proxy/suite_test.go
+++ b/pkg/proxy/suite_test.go
@@ -1,0 +1,13 @@
+package proxy
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestProxy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Proxy Suite")
+}


### PR DESCRIPTION
This PR:
* Modifies response writing to only create a responseLogger when LOG_LEVEL >= debug

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1886856