### PR TITLE
Re-use request pointer and context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/yhat/wsutil v0.0.0-20170731153501-1d66fa95c997
 	golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443 // indirect
-	golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b
+	golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b // indirect
 	golang.org/x/sys v0.0.0-20190620070143-6f217b454f45 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/pkg/handlers/authorization/roles_projects_service.go
+++ b/pkg/handlers/authorization/roles_projects_service.go
@@ -57,12 +57,12 @@ func loadFromOpenshift(roleConfig map[string]config.BackendRoleConfig, client cl
 		if !tokenReview.Status.Authenticated {
 			return nil, handlers.NewError("401", tokenReview.Status.Error)
 		}
-		ctx := &handlers.RequestContext{}
-		ctx.UserName = tokenReview.UserName()
-		ctx.Groups = tokenReview.Groups()
-		log.Debugf("User is %q in Groups: %v", ctx.UserName, ctx.Groups)
 
-		roles := evaluateRoles(client, ctx.UserName, ctx.Groups, roleConfig)
+		username := tokenReview.UserName()
+		groups := tokenReview.Groups()
+		log.Debugf("User is %q in Groups: %v", username, groups)
+
+		roles := evaluateRoles(client, username, groups, roleConfig)
 		projects, err := listProjects(client, token)
 		if err != nil {
 			return nil, err

--- a/pkg/handlers/types.go
+++ b/pkg/handlers/types.go
@@ -6,36 +6,19 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openshift/elasticsearch-proxy/pkg/apis"
-
 	log "github.com/sirupsen/logrus"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/elasticsearch-proxy/pkg/config"
 )
 
-type RequestContext struct {
-	Token            string
-	UserName         string
-	Projects         []apis.Project
-	Groups           []string
-	Roles            []string
-	WhiteListedNames []string
-}
+type ContextKey string
 
-func (context *RequestContext) IsWhiteListed(name string) bool {
-	for _, whitelisted := range context.WhiteListedNames {
-		if name == whitelisted {
-			return true
-		}
-	}
-	return false
-}
-
-func (context *RequestContext) RoleSet() sets.String {
-	return sets.NewString(context.Roles...)
-}
+const (
+	UsernameKey ContextKey = "username"
+	ProjectsKey ContextKey = "projects"
+	RolesKey    ContextKey = "roles"
+	SubjectKey  ContextKey = "subject"
+)
 
 type Options struct {
 	*config.Options
@@ -77,38 +60,11 @@ func NewStructuredError(err error) StructuredError {
 	}
 }
 
-//FnHandlerRequest is a function that can process a request
-type FnHandlerRequest func(req *http.Request, context *RequestContext) (*http.Request, error)
-
 //RequestHandler if a function that modifies a request.  Execution occurs
 //after authentication but before proxy to upstream
 type RequestHandler interface {
 	//Process the request and return the modification or error
-	Process(req *http.Request, context *RequestContext) (*http.Request, error)
+	Process(req *http.Request) (*http.Request, error)
 	//Name of the request handler
 	Name() string
-}
-
-//SimpleRequestHandler is a simple container to modify requests
-type SimpleRequestHandler struct {
-	name      string
-	processor FnHandlerRequest
-}
-
-//Name of the requesthandler
-func (h *SimpleRequestHandler) Name() string {
-	return h.name
-}
-
-//Process the Request
-func (h *SimpleRequestHandler) Process(req *http.Request, context *RequestContext) (*http.Request, error) {
-	return h.processor(req, context)
-}
-
-//NewRequestHandler creates a named wrapper to a requesthandler function
-func NewRequestHandler(name string, handler FnHandlerRequest) *SimpleRequestHandler {
-	return &SimpleRequestHandler{
-		name,
-		handler,
-	}
 }

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/http2"
-
 	configOptions "github.com/openshift/elasticsearch-proxy/pkg/config"
 	handlers "github.com/openshift/elasticsearch-proxy/pkg/handlers"
 	"github.com/openshift/elasticsearch-proxy/pkg/util"
@@ -67,12 +65,6 @@ func NewReverseProxy(target *url.URL, upstreamFlush time.Duration, rootCAs []str
 		transport.TLSClientConfig = &tls.Config{
 			RootCAs: pool,
 		}
-	}
-	if err := http2.ConfigureTransport(transport); err != nil {
-		if len(rootCAs) > 0 {
-			return nil, err
-		}
-		log.Warnf("Failed to configure http2 transport: %v", err)
 	}
 	proxy.Transport = transport
 


### PR DESCRIPTION
### Description
This PR addresses three HTTP request handling issues in custom elasticsearch-proxy handlers:
1. It replaces request copies by re-using the request pointer provided by `ServeHTTP`.
2. It replaces the custom request context implementation and copying by using the `http.Request` context.
3. Remove http2 transport configuration for upstream calls to Elasticsearch, because Elasticsearch does not support HTTP2 yet.
 
/cc @blockloop 
/assign @ewolinetz 