### PR TITLE
Bug 1895581: Quote individual project names in proxy header

### DIFF
--- a/pkg/handlers/authorization/handler.go
+++ b/pkg/handlers/authorization/handler.go
@@ -3,6 +3,7 @@ package authorization
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -83,7 +84,7 @@ func (auth *authorizationHandler) Process(req *http.Request) (*http.Request, err
 		projectNames := []string{}
 		projectUIDs := []string{}
 		for _, project := range projects {
-			projectNames = append(projectNames, project.Name)
+			projectNames = append(projectNames, fmt.Sprintf("%q", project.Name))
 			projectUIDs = append(projectUIDs, project.UUID)
 		}
 

--- a/pkg/handlers/authorization/handler_test.go
+++ b/pkg/handlers/authorization/handler_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Process", func() {
 			It("should add a user's projects to the request", func() {
 				entries, ok := req.Header["X-Ocp-Ns"]
 				Expect(ok).To(BeTrue(), fmt.Sprintf("Expected a user's projects to be added to be proxy headers: %v", req.Header))
-				Expect(entries).To(Equal([]string{"projecta,projectb"}))
+				Expect(entries).To(Equal([]string{"\"projecta\",\"projectb\""}))
 			})
 			It("should add a user's project uids to the request", func() {
 				entries, ok := req.Header["X-Ocp-Nsuid"]


### PR DESCRIPTION
### Description

By changing how list of projects is formatted we can start using
different - possibly a lot performant - query in DLS filter.

Watch for associated PR in https://github.com/openshift/elasticsearch-proxy
because the change must be merged in both repos in sync.

/cc @vimalk78 
/assign @jcantrill

/cherry-pick release-4.5

### Links
- Depending on PR(s): https://github.com/openshift/origin-aggregated-logging/pull/2032
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1895581