### PR TITLE
Bug 1913801: Quote individual project names in proxy header

### DIFF
--- a/pkg/handlers/authorization/handler.go
+++ b/pkg/handlers/authorization/handler.go
@@ -2,6 +2,7 @@ package authorization
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -72,7 +73,7 @@ func (auth *authorizationHandler) Process(req *http.Request, context *handlers.R
 		projectNames := []string{}
 		projectUIDs := []string{}
 		for _, project := range context.Projects {
-			projectNames = append(projectNames, project.Name)
+			projectNames = append(projectNames, fmt.Sprintf("%q", project.Name))
 			projectUIDs = append(projectUIDs, project.UUID)
 		}
 		req.Header.Add(headerForwardedNamespace, strings.Join(projectNames, ","))

--- a/pkg/handlers/authorization/handler_test.go
+++ b/pkg/handlers/authorization/handler_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Process", func() {
 			It("should add a user's projects to the request", func() {
 				entries, ok := req.Header["X-Ocp-Ns"]
 				Expect(ok).To(BeTrue(), fmt.Sprintf("Expected a user's projects to be added to be proxy headers: %v", req.Header))
-				Expect(entries).To(Equal([]string{"projecta,projectb"}))
+				Expect(entries).To(Equal([]string{"\"projecta\",\"projectb\""}))
 			})
 			It("should add a user's project uids to the request", func() {
 				entries, ok := req.Header["X-Ocp-Nsuid"]


### PR DESCRIPTION
### Description

Manual cherry-pick of https://github.com/openshift/elasticsearch-proxy/pull/68

By changing how list of projects is formatted we can start using
different - possibly a lot performant - query in DLS filter.

Watch for associated PR in https://github.com/openshift/origin-aggregated-logging
because the change must be merged in both repos in sync.

/cc @jcantrill 
/assign @ewolinetz 

### Links
- Depending on PR(s): https://github.com/openshift/origin-aggregated-logging/pull/2040
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1913801
