### PR TITLE
Update ownerfiles to autolabel PRs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,20 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-approvers:
-  - jcantrill
-  - ewolinetz
-  - alanconway
-reviewers:
-  - jcantrill
-  - ewolinetz
-  - lukas-vlcek
-  - alanconway
-  - igor-karpukhin
-  - vimalk78
-  - syedriko
-  - periklis
+filters:
+  ".*":
+    approvers:
+      - jcantrill
+      - ewolinetz
+      - alanconway
+    reviewers:
+      - jcantrill
+      - ewolinetz
+      - lukas-vlcek
+      - alanconway
+      - igor-karpukhin
+      - vimalk78
+      - syedriko
+      - periklis
+  "Dockerfile(?:\\.in)?$":   # matches Dockerfile, Dockerfile.in
+    labels:
+      - midstream/Dockerfile
 component: "Logging"


### PR DESCRIPTION
### Description
This PR modifies the owner file to autolabel PRs on Dockerfile changes so we can query to sync to midstream