### PR TITLE
Fix license labels to Apache-2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ LABEL \
         io.k8s.display-name="OpenShift ElasticSearch Proxy" \
         io.k8s.description="OpenShift ElasticSearch Proxy component of OpenShift Cluster Logging" \
         io.openshift.tags="openshift,logging,elasticsearch" \
+        License="Apache-2.0" \
         maintainer="AOS Logging <aos-logging@redhat.com>" \
         name="openshift-logging/elasticsearch-proxy-rhel8" \
         com.redhat.component="elasticsearch-proxy-container" \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -27,6 +27,7 @@ LABEL \
         io.k8s.display-name="OpenShift ElasticSearch Proxy" \
         io.k8s.description="OpenShift ElasticSearch Proxy component of OpenShift Cluster Logging" \
         io.openshift.tags="openshift,logging,elasticsearch" \
+        License="Apache-2.0" \
         maintainer="AOS Logging <aos-logging@redhat.com>" \
         name="openshift-logging/elasticsearch-proxy-rhel8" \
         com.redhat.component="elasticsearch-proxy-container" \


### PR DESCRIPTION
### Description
This PR syncs the correct license labels from midstream to upstream.

To address: https://issues.redhat.com/browse/LOG-1750

/cc @igor-karpukhin 
