### PR TITLE
Fix environment variable name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 run: copy-es-certs
 	KUBERNETES_SERVICE_HOST="${KUBERNETES_SERVICE_HOST}" \
 	KUBERNETES_SERVICE_PORT="${KUBERNETES_SERVICE_PORT}" \
-	LOGLEVEL=trace go run ${MAIN_PKG} --listening-address=':60000' \
+	LOG_LEVEL=trace go run ${MAIN_PKG} --listening-address=':60000' \
         --tls-cert=$(TLS_CERTS_BASEDIR)/admin-cert \
         --tls-key=$(TLS_CERTS_BASEDIR)/admin-key \
         --upstream-ca=$(TLS_CERTS_BASEDIR)/admin-ca \


### PR DESCRIPTION
The env var name should match its reader expectation:
https://github.com/openshift/elasticsearch-proxy/blob/e4993d7a4816919a1d4a3c33a7eb2c72946330e0/cmd/proxy/main.go#L55

### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
