### PR TITLE
Log 1868: Changing Default Role Application Behavior

### DIFF
--- a/pkg/handlers/authorization/handler.go
+++ b/pkg/handlers/authorization/handler.go
@@ -93,14 +93,16 @@ func (auth *authorizationHandler) Process(req *http.Request) (*http.Request, err
 		ctx = context.WithValue(ctx, handlers.ProjectsKey, projects)
 
 		var roles []string
-		if auth.config.AuthDefaultRole != "" {
-			roles = append(roles, auth.config.AuthDefaultRole)
-		}
 
 		for name := range auth.config.AuthBackEndRoles {
 			if _, ok := rolesProjects.roles[name]; ok {
 				roles = append(roles, name)
 			}
+		}
+
+		if len(roles) == 0 && auth.config.AuthDefaultRole != "" {
+			log.Debugf("User has no roles. Adding default role: %s", auth.config.AuthDefaultRole)
+			roles = append(roles, auth.config.AuthDefaultRole)
 		}
 
 		rs := sets.NewString(roles...)


### PR DESCRIPTION
This PR changes the application of the default role when given a request. Previously, the default role would be applied to every request. This behavior is incorrect as the default role should be applied when no other roles are given. 

Due to this, the default role from the Elasticsearch Operator was incorrectly applied to many requests and caused them to occasionally fail. Namely the erroneous behavior was executing an unnecessary `dls_query`, which would result in a 500 error from OpenDistro.

/cc @igor-karpukhin 
/assign @periklis 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1868
