### PR TITLE
LOG-4321: 'tls: handshake failure' in elasticsearch-proxy pods when the cluster has FIPS enabled

### DIFF
--- a/pkg/proxy/http.go
+++ b/pkg/proxy/http.go
@@ -33,7 +33,6 @@ func (s *Server) ListenAndServe() {
 
 	cfg := &tls.Config{
 		MinVersion: tls.VersionTLS12,
-		MaxVersion: tls.VersionTLS12,
 		NextProtos: []string{"http/1.1"},
 	}
 


### PR DESCRIPTION
### Description
Relax the MaxVersion for incoming TLS to 1.3 in order to avoid TLS 1.2 without EMS in FIPS mode

/cc @periklis 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4321

